### PR TITLE
Fix category link in Featured

### DIFF
--- a/src/components/Home/Featured.tsx
+++ b/src/components/Home/Featured.tsx
@@ -58,10 +58,8 @@ export default function Featured() {
               : Number(product.price);
 
           // Ссылка на страницу продукта или на категорию
-          const catSlug =
-            typeof product.category === "object" && product.category !== null && "slug" in product.category
-              ? (product.category as { slug: string }).slug
-              : categories.find((cat) => cat.id === product.category)?.slug;
+          // Категория приходит как slug, поэтому просто используем его
+          const catSlug = product.category;
 
           return (
             <div


### PR DESCRIPTION
## Summary
- simplify Featured category slug handling

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684c0ae29350832386febee77fc7618c