### PR TITLE
Fix variant option ID parsing

### DIFF
--- a/src/lib/adapters.ts
+++ b/src/lib/adapters.ts
@@ -75,7 +75,7 @@ function adaptVariant(variant: ProductVariantRaw): ProductVariant {
       ? variant.option_values.map((v) => ({
           id: String(v.id),
           value: v.value,
-          optionId: String(v.option_id ?? v.option_id ?? ""),
+          optionId: String(v.option_id ?? ""),
         }))
       : [],
   };


### PR DESCRIPTION
## Summary
- simplify `optionId` mapping for product variants

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run format` *(fails: missing `prettier-plugin-tailwindcss`)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e2428108323a4ddef4f968e53a3