### PR TITLE
Enhance home page hero design

### DIFF
--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -7,7 +7,7 @@ export default function Hero() {
   return (
     <section
       className="
-        w-full
+        relative w-full overflow-hidden
         flex flex-col-reverse lg:flex-row
         items-start
         gap-6 lg:gap-10
@@ -16,8 +16,25 @@ export default function Hero() {
         px-3 xs:px-4 sm:px-6 md:px-10 xl:px-20
         max-w-[1400px] mx-auto
         text-left lg:text-left
+        rounded-3xl shadow bg-gradient-to-br from-yellow-50 via-pink-50 to-white
       "
     >
+      <Image
+        src="/tomato.png"
+        alt=""
+        width={120}
+        height={120}
+        className="absolute -top-6 -left-6 w-24 opacity-40 select-none"
+        aria-hidden="true"
+      />
+      <Image
+        src="/leaf.png"
+        alt=""
+        width={100}
+        height={100}
+        className="absolute bottom-0 right-0 w-20 opacity-50 select-none"
+        aria-hidden="true"
+      />
       {/* TEXT BLOCK */}
       <div className="flex-1 w-full flex flex-col items-start">
         <h1
@@ -39,12 +56,15 @@ export default function Hero() {
         <p className="mb-5 text-gray-700 text-sm xs:text-base w-full max-w-[420px] text-left">
           Готовим быстро, доставляем с заботой, работаем каждый день.
         </p>
+        <p className="mb-6 text-pink-600 font-semibold text-sm xs:text-base w-full max-w-[420px] text-left">
+          Почувствуйте вкус настоящей Италии уже сегодня
+        </p>
 
         <Link
           href="/menu"
           className="
             inline-block bg-pink-500 hover:bg-pink-600 text-white font-bold
-            px-6 xs:px-8 py-2.5 xs:py-3 rounded-full shadow transition
+            px-6 xs:px-8 py-2.5 xs:py-3 rounded-full shadow-lg transition
             text-base xs:text-lg mt-2
             text-left
           "


### PR DESCRIPTION
## Summary
- add gradient background and decorative images in hero section
- highlight tagline and button for better UX

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5fa0740483239d05f75a0c443c12